### PR TITLE
Fixed a xml bug that causes Magento to be unable to load the theme.

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -23,7 +23,7 @@
 			<argument name="masterConfig" xsi:type="object">Cardgate\Payment\Model\Config\Master</argument>
 		</arguments>
 	</type>
-	<virtualType name="Magento\Framework\App\Config\PreProcessorComposite">
+	<virtualType name="PreProcessorCardgate" type="Magento\Framework\App\Config\PreProcessorComposite">
 		<arguments>
 			<argument name="processors" xsi:type="array">
 				<item name="PreProcessorCardgate" xsi:type="object">Cardgate\Payment\Model\Config\Processor\PreProcessorCardgate</item>


### PR DESCRIPTION
It was throwing this error:
`Unable to load theme by specified key 'frontend/vendor/theme'`